### PR TITLE
Feature/apply bootstrap style

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,3 +47,14 @@ td {
 .alert-alert {
   @extend .alert-danger;
 }
+
+.field_with_errors {
+  display: contents;
+
+  // ***** 以下を修正 *****
+  input,
+  textarea {
+    @extend .is-invalid;
+  }
+  // ***** 以上を修正 *****
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -39,3 +39,11 @@ td {
 .break-word {
   word-break: break-word;
 }
+
+.alert-notice {
+  @extend .alert-success;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,3 +20,9 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
     border: 2px solid red;
   }
 }
+
+.base-container {
+  @extend .container-fluid;
+  max-width: var(--breakpoint-lg);
+  padding: 30px 15px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,7 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
   max-width: var(--breakpoint-lg);
   padding: 30px 15px;
 }
+
+body {
+  padding-top: 56px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,12 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 body {
   padding-top: 56px;
 }
+
+th,
+td {
+  vertical-align: middle !important;
+}
+
+.break-word {
+  word-break: break-word;
+}

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,9 +1,8 @@
 <% if @post.errors.any? %>
-  <div>
-    <ul>
-      <% @post.errors.full_messages.each do |msg| %>
-        <li><span style="color: red;"><%= msg %></span></li>
-      <% end %>
-    </ul>
-  </div>
+  <% @post.errors.full_messages.each do |msg| %>
+    <div class="alert alert-danger" role="alert">
+      <a href="#" class="close" data-dismiss="alert">×</a>
+      <%= msg %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,4 +1,6 @@
 <% flash.each do |flash_type, msg| %>
-  <p><%= msg %></p>
-  <hr>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,12 @@
-
-<!-- ***** 以下を追加 ***** -->
-<%= link_to "投稿一覧", posts_path %>
-<%= link_to "新規投稿", new_post_path %>
-<hr>
-<!-- ***** 以上を追加 ***** -->
+<nav class="navbar navbar-expand-sm navbar-dark bg-primary fixed-top">
+  <span class="navbar-brand">メッセージ投稿アプリ</span>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+    <div class="navbar-nav">
+      <%= link_to "投稿一覧", posts_path, class: "nav-item nav-link active" %>
+      <%= link_to "新規投稿", new_post_path, class: "nav-item nav-link active" %>
+    </div>
+  </div>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,9 @@
     <title>PostBootstrapApp5</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <!-- ***** 次を追加 ***** -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <!-- ***** 以上を追加 ***** -->
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,9 +12,16 @@
   </head>
 
   <body>
-    <%= render "layouts/header" %>
-    <%= render "layouts/flash" %>
-
-    <%= yield %>
+    <!-- ***** 以下を修正 ***** -->
+    <header>
+      <%= render "layouts/header" %>
+    </header>
+    <main>
+      <%= render "layouts/flash" %>
+      <div class="base-container">
+        <%= yield %>
+      </div>
+    </main>
+    <!-- ***** 以上を修正 ***** -->
   </body>
 </html>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,15 +1,14 @@
 <%= render "layouts/error_messages" %>
-
 <%= form_with model: @post, local: true do |form| %>
-  <div>
+  <div class="form-group">
     <%= form.label :title %>
-    <%= form.text_field :title %>
+    <%= form.text_field :title, class: "form-control" %>
   </div>
-  <div>
+  <div class="form-group">
     <%= form.label :content %>
-    <%= form.text_field :content %>
+    <%= form.text_area :content, class: "form-control", rows: 10 %>
   </div>
   <div>
-    <%= form.submit button_value %>
+    <%= form.submit button_value, class: "btn btn-primary btn-block" %>
   </div>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,21 +1,27 @@
-<h1>投稿一覧</h1>
-<table>
-  <thead>
+<h1 class="text-center">投稿一覧</h1>
+<table class="table table-bordered table-striped mt-4">
+  <thead class="table-primary">
     <tr>
       <th scope="col">No.</th>
-      <th scope="col">タイトル</th>
+      <th scope="col" class="w-100">タイトル</th>
       <th scope="col"></th>
     </tr>
   </thead>
   <tbody>
     <% @posts.each.with_index(1) do |post, i| %>
       <tr>
-        <th scope="row"><%= i %></th>
-        <td><%= post.title %></td>
-        <td>
-          <%= link_to "詳細", post %>
-          <%= link_to "編集", edit_post_path(post) %>
-          <%= link_to "削除", post, method: :delete, data: { confirm: "削除しますか?" } %>
+        <th scope="row" class="text-right"><%= i %></th>
+        <td class="break-word"><%= post.title %></td>
+        <td class="text-nowrap">
+          <%= link_to post, class: "btn btn-primary" do %>
+            <i class="fas fa-envelope-open-text"></i> <span class="d-none d-md-inline"> 詳細</span>
+          <% end %>
+          <%= link_to edit_post_path(post), class: "btn btn-success" do %>
+            <i class="far fa-edit"></i> <span class="d-none d-md-inline"> 編集</span>
+          <% end %>
+          <%= link_to post, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-danger" do %>
+            <i class="far fa-trash-alt"></i> <span class="d-none d-md-inline"> 削除</span>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,3 +1,9 @@
-<h1>投稿詳細</h1>
-<p>タイトル <%= @post.title %></p>
-<p>内容 <%= @post.content %></p>
+<h1 class="text-center">詳細表示</h1>
+<section class="card border-dark mt-5">
+  <div class="card-header">
+    <h4><%= @post.title %></h4>
+  </div>
+  <div class="card-body">
+    <p class="card-text"><%= simple_format(h @post.content) %></p>
+  </div>
+</section>


### PR DESCRIPTION
## 概要
- ブートストラップで装飾

### やったこと
- viewportを追加

- base-containerクラスをつけ、中央揃え
- ヘッダーに Bootstrap の ナビバー利用
レスポンシブ対応
navbar-expand-sm の sm の箇所を調整することで，ハンバーガーメニューに切り替わる横幅を変更
ナビバーが上部で固定されるように fixed-top を入れておく

- フォームに Bootstrap でスタイルを追加
メッセージの投稿で「改行」を使用できるようにするため，text-field から text-area に変更しておきます。

- 詳細表示で Bootstrap の カード を利用
- 一覧表示で Bootstrap の テーブル を利用
- フラッシュで Bootstrap の アラート を利用
- エラーメッセージで Bootstrap の アラート を利用
